### PR TITLE
Add support for pro icons, fix #45

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you bought font awesome pro icons, you can import them here.
 
 :exclamation: By importing pro icons you acknowledge that it is your obligation to keep these files private. This includes **not** uploading your package to github or other public file sharing services.
 
-- [Download this package's source](https://github.com/michaelspiss/font_awesome_flutter/archive/master.zip), extract the folder and move it to a location of your choice
+- Download this package's newest release, extract the folder and move it to a location of your choice
 - Remove `#`s from `pubspec.yaml` at the indicated position
 - run `flutter packages get`
 - Download your font awesome pro icons (web version)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,26 @@ class MyWidget extends StatelessWidget {
 
 View the Flutter app in the `example` directory to see all the available `FontAwesomeIcons`.
 
+## Include pro icons
+
+If you bought font awesome pro icons, you can import them here. 
+
+:exclamation: By importing pro icons you acknowledge that it is your obligation to keep these files private, this includes **not** uploading your package to github or other public file sharing services.
+
+- [Download this package's source](https://github.com/michaelspiss/font_awesome_flutter/archive/master.zip), extract the folder and move it to a location of your choice
+- Download your font awesome pro icons (web version)
+- Move all `.ttf` files from the `webfonts` directory to this package's lib/fonts (replace existing fonts)
+- Move `icons.json` from `metadata` to this directory (package root)
+- Run `./tool/update.sh` (from this package's root)
+- Remove `#`s from `pubspec.yaml` at the indicated position
+- Add dependency to your project with the source being the location of your choice:
+```yaml
+dependencies:
+  font_awesome_flutter:
+    path: /path/to/font_awesome_flutter
+    ...
+```
+
 ## Contributors
 
   - Brian Egan

--- a/README.md
+++ b/README.md
@@ -43,19 +43,19 @@ If you bought font awesome pro icons, you can import them here.
 :exclamation: By importing pro icons you acknowledge that it is your obligation to keep these files private. This includes **not** uploading your package to github or other public file sharing services.
 
 - [Download this package's source](https://github.com/michaelspiss/font_awesome_flutter/archive/master.zip), extract the folder and move it to a location of your choice
-- In your project's dependencies, replace the version tag for `font_awesome_flutter` with the path to your custom installation:
+- Remove `#`s from `pubspec.yaml` at the indicated position
+- run `flutter packages get`
+- Download your font awesome pro icons (web version)
+- Move all `.ttf` files from the `webfonts` directory to this package's lib/fonts (replace existing fonts)
+- Move `icons.json` from `metadata` to this directory
+- Run `./tool/update.sh`
+- In your project's dependencies, replace the version tag for `font_awesome_flutter` with the path to your custom installation.
 ```yaml
 dependencies:
   font_awesome_flutter:
     path: /path/to/font_awesome_flutter
     ...
 ```
-- Remove `#`s from `pubspec.yaml` at the indicated position
-- Run `pub get`
-- Download your font awesome pro icons (web version)
-- Move all `.ttf` files from the `webfonts` directory to this package's lib/fonts (replace existing fonts)
-- Move `icons.json` from `metadata` to this directory (package root)
-- Run `./tool/update.sh` (from this package's root)
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ dependencies:
     path: /path/to/font_awesome_flutter
     ...
 ```
+- Uncomment `IconDataLight` in `lib/icon_data.dart`
 
 ## Contributors
 
   - Brian Egan
   - Phil Plante
+  - Michael Spiss

--- a/README.md
+++ b/README.md
@@ -40,21 +40,22 @@ View the Flutter app in the `example` directory to see all the available `FontAw
 
 If you bought font awesome pro icons, you can import them here. 
 
-:exclamation: By importing pro icons you acknowledge that it is your obligation to keep these files private, this includes **not** uploading your package to github or other public file sharing services.
+:exclamation: By importing pro icons you acknowledge that it is your obligation to keep these files private. This includes **not** uploading your package to github or other public file sharing services.
 
 - [Download this package's source](https://github.com/michaelspiss/font_awesome_flutter/archive/master.zip), extract the folder and move it to a location of your choice
-- Download your font awesome pro icons (web version)
-- Move all `.ttf` files from the `webfonts` directory to this package's lib/fonts (replace existing fonts)
-- Move `icons.json` from `metadata` to this directory (package root)
-- Run `./tool/update.sh` (from this package's root)
-- Remove `#`s from `pubspec.yaml` at the indicated position
-- Add dependency to your project with the source being the location of your choice:
+- In your project's dependencies, replace the version tag for `font_awesome_flutter` with the path to your custom installation:
 ```yaml
 dependencies:
   font_awesome_flutter:
     path: /path/to/font_awesome_flutter
     ...
 ```
+- Remove `#`s from `pubspec.yaml` at the indicated position
+- Run `pub get`
+- Download your font awesome pro icons (web version)
+- Move all `.ttf` files from the `webfonts` directory to this package's lib/fonts (replace existing fonts)
+- Move `icons.json` from `metadata` to this directory (package root)
+- Run `./tool/update.sh` (from this package's root)
 
 ## Contributors
 

--- a/lib/icon_data.dart
+++ b/lib/icon_data.dart
@@ -28,3 +28,13 @@ class IconDataRegular extends IconData {
           fontPackage: 'font_awesome_flutter',
         );
 }
+
+// Pro only
+class IconDataLight extends IconData {
+  const IconDataLight(int codePoint)
+      : super(
+          codePoint,
+          fontFamily: 'FontAwesomeLight',
+          fontPackage: 'font_awesome_flutter',
+        );
+}

--- a/lib/icon_data.dart
+++ b/lib/icon_data.dart
@@ -29,7 +29,8 @@ class IconDataRegular extends IconData {
         );
 }
 
-// Pro only
+// Uncomment to be able to use (pro) light icons if installed
+/*
 class IconDataLight extends IconData {
   const IconDataLight(int codePoint)
       : super(
@@ -38,3 +39,5 @@ class IconDataLight extends IconData {
           fontPackage: 'font_awesome_flutter',
         );
 }
+*/
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,3 +28,9 @@ flutter:
       fonts:
         - asset: lib/fonts/fa-solid-900.ttf
           weight: 900
+# To support pro icons, drop fa-light-300.ttf into lib/fonts,
+# regenerate the icon collection and uncomment the following lines:
+#    - family: FontAwesomeLight
+#      fonts:
+#        - asset: lib/fonts/fa-light-300.ttf
+#          weight: 300

--- a/tool/generate_font.dart
+++ b/tool/generate_font.dart
@@ -34,7 +34,7 @@ void main(List<String> arguments) {
         String name = '${style}_$iconName';
         iconDefinitions[name] = generateIconDefinition(
           name,
-          styles,
+          style,
           unicode,
         );
       }

--- a/tool/generate_font.dart
+++ b/tool/generate_font.dart
@@ -34,7 +34,7 @@ void main(List<String> arguments) {
         String name = '${style}_$iconName';
         iconDefinitions[name] = generateIconDefinition(
           name,
-          styles.first,
+          styles,
           unicode,
         );
       }

--- a/tool/update.sh
+++ b/tool/update.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
+if [ -e ./icons.json ];
+then 
+echo "Custom icons.json found, using local data only."
 
+dart ./tool/generate_font.dart ./icons.json
+dart ./tool/generate_example.dart ./icons.json
+dartfmt -w ./lib/font_awesome_flutter.dart
+dartfmt -w ./example/lib/icons.dart
+
+else
+echo "Updating icons to newest version."
 pushd lib/fonts/
 
 curl -O -L "https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/webfonts/fa-brands-400.ttf"
@@ -16,3 +26,4 @@ dartfmt -w ./lib/font_awesome_flutter.dart
 dartfmt -w ./example/lib/icons.dart
 
 rm /tmp/icons.json
+fi


### PR DESCRIPTION
Pro files must be provided by the developer, see installation instructions in the README.
It also fixes the issue documented [here](https://github.com/brianegan/font_awesome_flutter/pull/37#discussion_r292484190) and in #45 