### PR TITLE
Provide update script for Windows

### DIFF
--- a/tool/update.bat
+++ b/tool/update.bat
@@ -1,0 +1,25 @@
+@echo off
+
+if exist icons.json (
+    echo Custom icons.json found, using local data only.
+
+    dart .\tool\generate_font.dart .\icons.json
+    dart .\tool\generate_example.dart .\icons.json
+) else (
+    echo Updating free icons to newest version.
+    pushd lib\fonts
+
+    powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/webfonts/fa-brands-400.ttf', 'fa-brands-400.ttf')"
+    powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/webfonts/fa-regular-400.ttf', 'fa-regular-400.ttf')"
+    powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/webfonts/fa-solid-900.ttf', 'fa-solid-900.ttf')"
+
+    popd
+    powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/metadata/icons.json', 'icons.json')"
+
+    dart .\tool\generate_font.dart .\icons.json
+    dart .\tool\generate_example.dart .\icons.json
+    del "icons.json" /f /q
+)
+
+dartfmt -w .\lib\font_awesome_flutter.dart & ^
+dartfmt -w .\example\lib\icons.dart


### PR DESCRIPTION
This allows users to update the icons on Windows computers as well. Requires at least Windows 7.
The update mechanic works the same as in update.sh, but with the tweaks of #37 to recognize a
custom icons.json (https://github.com/brianegan/font_awesome_flutter/pull/37/commits/dd08ea2e5ff2812fe5a5569d33936ce14a518c15) already in there.