### PR TITLE
Include Font awesome attribution in license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -17,3 +17,8 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+Font Awesome Icons by @fontawesome - https://fontawesome.com
+License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1)


### PR DESCRIPTION
Attribution [similar to their own](https://github.com/FortAwesome/Font-Awesome/blob/master/css/all.css#L2-L3). Separated from the main license according to [LicenseRegistry](https://api.flutter.dev/flutter/foundation/LicenseRegistry-class.html). Not quite sure what to do if a user loads pro icons - we could remove the last line (link to free license) in the generator script - but I guess that would be overkill. Fixes #77 