### PR TITLE
Change suggestion on how to depend on pro icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,17 @@ a public github repository or other public file sharing services.
   * Move all `.ttf` files from the `webfonts` directory to this package's lib/fonts (replace existing fonts)
   * Move `icons.json` from `metadata` to this directory
   * Run `./tool/update.sh`
-  * In your project's dependencies, replace the version tag for `font_awesome_flutter` with the path to your custom installation.
+  * Add version `>= 4.7.0` to your project's dependencies, Override it with the path to your local installation
   
 ```yaml
 dependencies:
+  font_awesome_flutter: '>= 4.7.0'
+  ...
+  
+dependency_overrides:
   font_awesome_flutter:
-    path: /path/to/font_awesome_flutter
-    ...
+    path: /path/to/your/font_awesome_flutter
+  ...
 ```
 
 ### Duotone icons


### PR DESCRIPTION
The old way (depending on the local installation directly) caused a version conflict as soon as another dependency depends on `font_awesome_flutter` (as it requires it from "host" pub.dev) - which is solved by using a dependency override.
`4.7.0` is the first version published on pub.dev and as the api is fully backwards compatible, every package depending on `font_awesome_flutter` can use the local installation.