### PR TITLE
Fix build failure because of "private" icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 8.9.1
   * Fix #119: Inverted colors for duotone icons
+  * Fix #122: Skip icons marked as private during generation
 
 ## 8.9.0
   * Upgrade to Font Awesome icons 5.15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 8.9.1
   * Fix #119: Inverted colors for duotone icons
-  * Fix #122: Skip icons marked as private during generation
+  * Fix #122: Build failure due to missing glyphs in web fonts
 
 ## 8.9.0
   * Upgrade to Font Awesome icons 5.15

--- a/example/lib/icons.dart
+++ b/example/lib/icons.dart
@@ -586,11 +586,6 @@ final icons = <ExampleIcon>[
   ExampleIcon(FontAwesomeIcons.fontAwesome, 'fontAwesome'),
   ExampleIcon(FontAwesomeIcons.fontAwesomeAlt, 'fontAwesomeAlt'),
   ExampleIcon(FontAwesomeIcons.fontAwesomeFlag, 'fontAwesomeFlag'),
-  ExampleIcon(FontAwesomeIcons.fontAwesomeLogoFull, 'fontAwesomeLogoFull'),
-  ExampleIcon(
-      FontAwesomeIcons.solidFontAwesomeLogoFull, 'solidFontAwesomeLogoFull'),
-  ExampleIcon(
-      FontAwesomeIcons.brandsFontAwesomeLogoFull, 'brandsFontAwesomeLogoFull'),
   ExampleIcon(FontAwesomeIcons.fonticons, 'fonticons'),
   ExampleIcon(FontAwesomeIcons.fonticonsFi, 'fonticonsFi'),
   ExampleIcon(FontAwesomeIcons.footballBall, 'footballBall'),

--- a/lib/font_awesome_flutter.dart
+++ b/lib/font_awesome_flutter.dart
@@ -584,10 +584,6 @@ class FontAwesomeIcons {
   static const IconData fontAwesome = const IconDataBrands(0xf2b4);
   static const IconData fontAwesomeAlt = const IconDataBrands(0xf35c);
   static const IconData fontAwesomeFlag = const IconDataBrands(0xf425);
-  static const IconData fontAwesomeLogoFull = const IconDataRegular(0xf4e6);
-  static const IconData solidFontAwesomeLogoFull = const IconDataSolid(0xf4e6);
-  static const IconData brandsFontAwesomeLogoFull =
-      const IconDataBrands(0xf4e6);
   static const IconData fonticons = const IconDataBrands(0xf280);
   static const IconData fonticonsFi = const IconDataBrands(0xf3a2);
   static const IconData footballBall = const IconDataSolid(0xf44e);

--- a/tool/generate_example.dart
+++ b/tool/generate_example.dart
@@ -17,6 +17,12 @@ void main(List<String> arguments) {
 
   for (String iconName in icons.keys) {
     var icon = icons[iconName];
+
+    // At least one icon does not have a glyph in the font files. This property
+    // is marked with "private": true in icons.json
+    if((icon as Map<String, dynamic>).containsKey('private') && icon['private'])
+      continue;
+
     List<String> styles = (icon['styles'] as List).cast<String>();
 
     if (styles.length > 1) {

--- a/tool/generate_font.dart
+++ b/tool/generate_font.dart
@@ -19,6 +19,12 @@ void main(List<String> arguments) {
 
   for (String iconName in icons.keys) {
     var icon = icons[iconName];
+
+    // At least one icon does not have a glyph in the font files. This property
+    // is marked with "private": true in icons.json
+    if((icon as Map<String, dynamic>).containsKey('private') && icon['private'])
+      continue;
+
     var unicode = icon['unicode'];
     List<String> styles = (icon['styles'] as List).cast<String>();
 


### PR DESCRIPTION
Some icons seem to only be available "theoretically" in `icons.json`, but their glyphs are missing from the web fonts. This property is marked with a `"private": true` in `icons.json`.