### PR TITLE
Set line height to 1

### DIFF
--- a/lib/src/fa_icon.dart
+++ b/lib/src/fa_icon.dart
@@ -110,6 +110,7 @@ class FaIcon extends StatelessWidget {
           fontSize: iconSize,
           fontFamily: icon.fontFamily,
           package: icon.fontPackage,
+          height: 1,
         ),
       ),
     );


### PR DESCRIPTION
The line height must be set to 1. Otherwise the icons are offset