### PR TITLE
fix generating digit only icon names from fa version 6

### DIFF
--- a/tool/generate_font.dart
+++ b/tool/generate_font.dart
@@ -177,6 +177,12 @@ String normalizeIconName(String iconName) {
     iconName = 'fiveHundredPx';
   }
 
+  // digit only icons
+  RegExp exp = new RegExp(r"^[0-9]{1}$");
+  if (exp.hasMatch(iconName)) {
+    iconName = 'digit$iconName';
+  }
+
   return new ReCase(iconName).camelCase;
 }
 


### PR DESCRIPTION
There are new digit icons (from 0 to 9) in version 6. Their `regular` generated variable names were incorrect.
#145 