### PR TITLE
Remove duplicate key from DuoTone Icon

### DIFF
--- a/lib/src/fa_duotone_icon.dart
+++ b/lib/src/fa_duotone_icon.dart
@@ -52,7 +52,6 @@ class FaDuotoneIcon extends StatelessWidget {
     return Semantics(
       label: semanticLabel,
       child: Stack(
-        key: key,
         children: <Widget>[
           FaIcon(
             icon,


### PR DESCRIPTION
In testing, if giving a FaDuotone a key, the widget tester finds 2 widgets in the tree with the key because the key is given to the Stack and passed to the super initializer as well. 