### PR TITLE
Update pubspec.yaml

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,9 @@
 name: font_awesome_flutter_example
 description: The Font Awesome Flutter Gallery
 
+environment:
+  sdk: ">=2.0.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter


### PR DESCRIPTION
Added the `environment:sdk:` field to the `example/pubspec.yaml` file.

The `example/pubspec.yaml` requires the environment field or else a "Lower-bound SDK constraint" warning is displayed and the flutter packages get command will fail.