### PR TITLE
Update README.md to

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,29 @@ By default, if run without arguments and no `icons.json` in `lib/fonts` exists, 
 newest free version of font awesome.
 
 ### Setup
-To use your custom version, you must first clone [this repository](https://github.com/fluttercommunity/font_awesome_flutter.git)
-to a location of your choice and run `flutter pub get` inside. This installs all dependencies.
+To use a custom version, you will need to:
+1. Clone [this repository](https://github.com/fluttercommunity/font_awesome_flutter.git)
+to a location of your choice
+1. Comment out lines the following lines in `pubspec.yaml`:
+  ```yaml
+  ...
+  flutter:
+    fonts:
+  ...
+  ```
+3. run `flutter pub get` from the root, to install all dependencies
+3. Uncomment the lines in `pubspec.yaml` from the previous step, the configurator uses those lines in the generation
+3. Add the files you need in `lib/fonts`, to enable pro icons see [here](https://github.com/fluttercommunity/font_awesome_flutter/edit/master/README.md#enable-pro-icons)
+3. Run the configurator
 
+#### Configurator
 The configurator is located in the `util` folder and can be started by running `configurator.bat` on Windows, or 
 `./configurator.sh` on linux and mac. All following examples use the `.sh` version, but work same for `.bat`.
 (If on windows, omit the `./` or replace it with `.\`.)
+
 An overview of available options can be viewed with `./configurator.sh --help`.
 
+#### Adding custom font_awesome_flutter in your app
 To use your customized version in an app, go to the app's `pubspec.yaml` and add a dependency for
 `font_awesome_flutter: '>= 4.7.0'`. Then override the dependency's location:
 ```yaml


### PR DESCRIPTION
When running the setup for the first time I hit some problems that seem to be common with some other PR/issues
I have updated the readme to hopefully helps others in adding a custom version

From following the steps I hit these errors:
Example of running `flutter pub get` following steps in docs, similar issue in #216 :
```
Error detected in pubspec.yaml:
Expected "fonts" to be a list, but got null (Null).
Please correct the pubspec.yaml file at /Users/b099l3/Developer/font_awesome_flutter/pubspec.yaml
```

where I needed to comment out lines 24-25 in `pubspec.yaml`:
```yaml
...
flutter:
  fonts:
...
```

then from running `./util/configurator.sh` I got this:

```
####  #   #####################################################################
###  ###  ############ Font Awesome Flutter Configurator ######################
#   #   # #####################################################################
  
Using font_awesome_flutter version 10.1.0
Downloading https://api.github.com/repos/fluttercommunity/font_awesome_flutter/releases

Custom icons.json found, generating files
Duotone icons are no longer supported. Automatically disabled them.

Generating icon definitions
Formatted lib/font_awesome_flutter.dart
Formatted 1 file (1 changed) in 0.87 seconds.

Generating example code
Formatted example/lib/icons.dart
Formatted 1 file (1 changed) in 0.61 seconds.
Unhandled exception:
RangeError (index): Invalid value: Not in inclusive range 0..43: -1
#0      List.[] (dart:core-patch/growable_array.dart:260:36)
#1      adjustPubspecFontIncludes (file:///Users/b099l3/Developer//font_awesome_flutter/util/lib/main.dart:194:37)
#2      main (file:///Users/b099l3/Developer//font_awesome_flutter/util/lib/main.dart:165:3)
<asynchronous suspension>
```

Where I realised the generation relies on those lines being there so uncomment, and re-ran to find no errors.


