### PR TITLE
Update pub.dev links

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,8 @@
 name: font_awesome_flutter
 description: The Font Awesome Icon pack available as Flutter Icons. Provides 1600 additional icons to use in your apps.
 maintainer: Michael Spiss (@michaelspiss)
-homepage: https://github.com/fluttercommunity/font_awesome_flutter
+repository: https://github.com/fluttercommunity/font_awesome_flutter
+issue_tracker: https://github.com/fluttercommunity/font_awesome_flutter/issues
 version: 10.1.0
 
 environment:


### PR DESCRIPTION
With this PR, the right section on pub.dev will show the View/report issues link to GitHub again, like [here](https://pub.dev/packages/android_id) (the show-logic was recently changed).