### PR TITLE
Add Support for Custom Kit Icons -- FontAwesome

### DIFF
--- a/lib/src/icon_data.dart
+++ b/lib/src/icon_data.dart
@@ -83,3 +83,16 @@ class IconDataThin extends IconData {
           fontPackage: 'font_awesome_flutter',
         );
 }
+
+/// [IconData] for font awesome custom kit icon from a code point. Only works if
+/// custom kit is enabled
+///
+/// Code points can be obtained from fontawesome.com
+class IconDataCustom extends IconData {
+  const IconDataCustom(int codePoint)
+      : super(
+    codePoint,
+    fontFamily: 'FontAwesomeCustom',
+    fontPackage: 'font_awesome_flutter',
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,11 +36,15 @@ flutter:
       fonts:
         - asset: lib/fonts/fa-solid-900.ttf
           weight: 900
-#    - family: FontAwesomeLight
-#      fonts:
-#        - asset: lib/fonts/fa-light-300.ttf
-#          weight: 300
-#    - family: FontAwesomeThin
-#      fonts:
-#        - asset: lib/fonts/fa-thin-100.ttf
-#          weight: 100
+    - family: FontAwesomeLight
+      fonts:
+        - asset: lib/fonts/fa-light-300.ttf
+          weight: 300
+    - family: FontAwesomeThin
+      fonts:
+        - asset: lib/fonts/fa-thin-100.ttf
+          weight: 100
+    - family: FontAwesomeCustom
+      fonts:
+        - asset: lib/fonts/custom-icons.ttf
+          weight: 400

--- a/util/lib/custom_icon_transfer_object.dart
+++ b/util/lib/custom_icon_transfer_object.dart
@@ -1,0 +1,73 @@
+class CustomIconTransferObject {
+  final List<String> changes;
+  final List<String> ligatures;
+  final SearchObject search;
+  final List<String> styles;
+  final String unicode;
+  final String label;
+  final Map<String, SvgTransferObject> svg;
+  final List<String> free;
+
+  CustomIconTransferObject(
+      {this.changes = const ['6.4.0'],
+      this.ligatures = const [],
+      this.search = const SearchObject(),
+      this.styles = const ['custom'],
+      required this.unicode,
+      required this.label,
+      required this.svg,
+      this.free = const []});
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> svgEntry = {};
+    svg.forEach((key, value) {
+      svgEntry[key] = value.toJson();
+    });
+    return {
+      'changes': changes,
+      'ligatures': ligatures,
+      'search': search.toJson(),
+      'styles': styles,
+      'unicode': unicode,
+      'label': label,
+      'svg': svgEntry,
+      'free': free,
+    };
+  }
+}
+
+class SearchObject {
+  final List<String> terms;
+  const SearchObject({this.terms = const []});
+  factory SearchObject.fromJson(Map<String, dynamic> json) =>
+      SearchObject(terms: (json['terms'] as List<dynamic>?)?.map((e) => e as String).toList() ?? []);
+  Map<String, dynamic> toJson() => {'terms': terms};
+}
+
+class SvgTransferObject {
+  SvgTransferObject(
+      {required this.lastModified, required this.raw, required this.viewBox, required this.width, required this.height, required this.path});
+  final int? lastModified;
+  final String raw;
+  final List<int> viewBox;
+  final int width;
+  final int height;
+  final String path;
+
+  factory SvgTransferObject.fromJson(Map<String, dynamic> json) => SvgTransferObject(
+      lastModified: json['last_modified'],
+      raw: json['raw'],
+      viewBox: json['viewBox'],
+      width: json['width'],
+      height: json['height'],
+      path: json['path']);
+
+  Map<String, dynamic> toJson() => {
+        'last_modified': lastModified,
+        'raw': raw,
+        'viewBox': viewBox,
+        'width': width,
+        'height': height,
+        'path': path,
+      };
+}


### PR DESCRIPTION
Add Support for Custom Kit Icons -- FontAwesome (available on version >=6.4.0)

- First: Download the custom PRO Kit that you or your team has created on FontAwesome
- Second: Copy the `webfonts/custom-icons.ttf` file and `js/custom-icons.js` file into `lib/fonts/` folder, at the same level where you store the `icons.json` file.
- Last: run command `./configurator.sh` on Mac or `./configurator.bat` on Windows with arguments `install-custom-kit` or abbr. `k`