### PR TITLE
fix: code-generation for /example conditional in util/lib/main.dart

### DIFF
--- a/util/lib/main.dart
+++ b/util/lib/main.dart
@@ -162,10 +162,17 @@ void main(List<String> rawArgs) async {
   );
 
   print(blue('\nGenerating example code'));
-  writeCodeToFile(
-    () => generateExamplesListClass(metadata),
-    'example/lib/icons.dart',
-  );
+  final exampleDir = Directory('example');
+  if (exampleDir.existsSync()) {
+    writeCodeToFile(
+      () => generateExamplesListClass(metadata),
+      'example/lib/icons.dart',
+    );
+  } else {
+    print(
+      yellow('Skipping example code generation: example/ folder not found.'),
+    );
+  }
 
   if (args['dynamic']) {
     writeCodeToFile(


### PR DESCRIPTION
Issue: #291

Fixes error on deleting /example folder

Lazy approach:
- Just made example code generation conditional in /utils/lib/main.dart

Longtime Fix:
- Decouple example completely