### PR TITLE
feat: add pro(+) fonts

### DIFF
--- a/lib/src/icon_data.dart
+++ b/lib/src/icon_data.dart
@@ -120,3 +120,147 @@ class IconDataSharpSolid extends IconData {
         fontPackage: 'font_awesome_flutter',
       );
 }
+
+/// [IconData] for a font awesome chisel thin icon from a code point. Only works if
+/// chisel icons (font awesome pro+, v7+) have been installed.
+///
+/// Code points can be obtained from fontawesome.com
+class IconDataChiselRegular extends IconData {
+  const IconDataChiselRegular(super.codePoint)
+    : super(
+        fontFamily: 'FontAwesomeChiselRegular',
+        fontPackage: 'font_awesome_flutter',
+      );
+}
+
+/// [IconData] for a font awesome chisel solid icon from a code point. Only works if
+/// chisel icons (font awesome pro+, v7+) have been installed.
+///
+/// Code points can be obtained from fontawesome.com
+class IconDataEtchSolid extends IconData {
+  const IconDataEtchSolid(super.codePoint)
+    : super(
+        fontFamily: 'FontAwesomeEtchSolid',
+        fontPackage: 'font_awesome_flutter',
+      );
+}
+
+/// [IconData] for a font awesome notdog solid icon from a code point. Only works if
+/// Notdog icons (font awesome pro+, v7+) have been installed.
+///
+/// Code points can be obtained from fontawesome.com
+class IconDataNotdogSolid extends IconData {
+  const IconDataNotdogSolid(super.codePoint)
+    : super(
+        fontFamily: 'FontAwesomeNotdogSolid',
+        fontPackage: 'font_awesome_flutter',
+      );
+}
+
+/// [IconData] for a font awesome graphite solid icon from a code point. Only works if
+/// graphite icons (font awesome pro+, v7+) have been installed.
+///
+/// Code points can be obtained from fontawesome.com
+class IconDataJellyRegular extends IconData {
+  const IconDataJellyRegular(super.codePoint)
+    : super(
+        fontFamily: 'FontAwesomeJellyRegular',
+        fontPackage: 'font_awesome_flutter',
+      );
+}
+
+/// [IconData] for a font awesome graphite solid icon from a code point. Only works if
+/// graphite icons (font awesome pro+, v7+) have been installed.
+///
+/// Code points can be obtained from fontawesome.com
+class IconDataJellyFillRegular extends IconData {
+  const IconDataJellyFillRegular(super.codePoint)
+    : super(
+        fontFamily: 'FontAwesomeJellyFillRegular',
+        fontPackage: 'font_awesome_flutter',
+       );
+}
+
+/// [IconData] for a font awesome graphite solid icon from a code point. Only works if
+/// graphite icons (font awesome pro+, v7+) have been installed.
+///
+/// Code points can be obtained from fontawesome.com
+class IconDataSlabRegular extends IconData {
+  const IconDataSlabRegular(super.codePoint)
+    : super(
+        fontFamily: 'FontAwesomeSlabRegular',
+        fontPackage: 'font_awesome_flutter',
+      );
+}
+
+/// [IconData] for a font awesome graphite solid icon from a code point. Only works if
+/// graphite icons (font awesome pro+, v7+) have been installed.
+///
+/// Code points can be obtained from fontawesome.com
+class IconDataSlabPressRegular extends IconData {
+  const IconDataSlabPressRegular(super.codePoint)
+    : super(
+        fontFamily: 'FontAwesomeSlabPressRegular',
+        fontPackage: 'font_awesome_flutter',
+      );
+}
+
+/// [IconData] for a font awesome graphite solid icon from a code point. Only works if
+/// graphite icons (font awesome pro+, v7+) have been installed.
+///
+/// Code points can be obtained from fontawesome.com
+class IconDataThumbprintLight extends IconData {
+  const IconDataThumbprintLight(super.codePoint)
+    : super(
+        fontFamily: 'FontAwesomeThumbprintLight',
+        fontPackage: 'font_awesome_flutter',
+      );
+}
+
+/// [IconData] for a font awesome whiteboard semibold icon from a code point. Only works if
+/// whiteboard icons (font awesome pro+, v7+) have been installed.
+///
+/// Code points can be obtained from fontawesome.com
+class IconDataWhiteboardSemibold extends IconData {
+  const IconDataWhiteboardSemibold(super.codePoint)
+    : super(
+        fontFamily: 'FontAwesomeWhiteboardSemibold',
+        fontPackage: 'font_awesome_flutter',
+      );
+}
+
+/// [IconData] for a font awesome utility semibold icon from a code point. Only works if
+/// utility icons (font awesome pro+, v7.1.0+) have been installed.
+///
+/// Code points can be obtained from fontawesome.com
+class IconDataUtilitySemibold extends IconData {
+  const IconDataUtilitySemibold(super.codePoint)
+    : super(
+        fontFamily: 'FontAwesomeUtilitySemibold',
+        fontPackage: 'font_awesome_flutter',
+      );
+}
+
+/// [IconData] for a font awesome utility fill semibold icon from a code point. Only works if
+/// utility fill icons (font awesome pro+, v7.1.0+) have been installed.
+///
+/// Code points can be obtained from fontawesome.com
+class IconDataUtilityFillSemibold extends IconData {
+  const IconDataUtilityFillSemibold(super.codePoint)
+    : super(
+        fontFamily: 'FontAwesomeUtilityFillSemibold',
+        fontPackage: 'font_awesome_flutter',
+      );
+}
+
+/// [IconData] for a font awesome graphite thin icon from a code point. Only works if
+/// graphite icons (font awesome pro+, v7.2.0+) have been installed.
+///
+/// Code points can be obtained from fontawesome.com
+class IconDataGraphiteThin extends IconData {
+  const IconDataGraphiteThin(super.codePoint)
+    : super(
+        fontFamily: 'FontAwesomeGraphiteThin',
+        fontPackage: 'font_awesome_flutter',
+      );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,3 +61,51 @@ flutter:
 #      fonts:
 #        - asset: lib/fonts/Font-Awesome-7-Sharp-Solid-900.otf
 #          weight: 900
+    - family: FontAwesomeChiselRegular
+      fonts:
+        - asset: lib/fonts/Font-Awesome-7-Chisel-Regular-400.otf
+          weight: 400
+    - family: FontAwesomeEtchSolid
+      fonts:
+        - asset: lib/fonts/Font-Awesome-7-Etch-Solid-900.otf
+          weight: 900
+    - family: FontAwesomeGraphiteThin
+      fonts:
+        - asset: lib/fonts/Font-Awesome-7-Graphite-Thin-100.otf
+          weight: 100
+    - family: FontAwesomeJellyFillRegular
+      fonts:
+        - asset: lib/fonts/Font-Awesome-7-Jelly-Fill-Regular-400.otf
+          weight: 400
+    - family: FontAwesomeJellyRegular
+      fonts:
+        - asset: lib/fonts/Font-Awesome-7-Jelly-Regular-400.otf
+          weight: 400
+    - family: FontAwesomeNotdogSolid
+      fonts:
+        - asset: lib/fonts/Font-Awesome-7-Notdog-Solid-900.otf
+          weight: 900
+    - family: FontAwesomeSlabPressRegular
+      fonts:
+        - asset: lib/fonts/Font-Awesome-7-Slab-Press-Regular-400.otf
+          weight: 400
+    - family: FontAwesomeSlabRegular
+      fonts:
+        - asset: lib/fonts/Font-Awesome-7-Slab-Regular-400.otf
+          weight: 400
+    - family: FontAwesomeThumbprintLight
+      fonts:
+        - asset: lib/fonts/Font-Awesome-7-Thumbprint-Light-300.otf
+          weight: 300
+    - family: FontAwesomeUtilityFillSemibold
+      fonts:
+        - asset: lib/fonts/Font-Awesome-7-Utility-Fill-Semibold-600.otf
+          weight: 600
+    - family: FontAwesomeUtilitySemibold
+      fonts:
+        - asset: lib/fonts/Font-Awesome-7-Utility-Semibold-600.otf
+          weight: 600
+    - family: FontAwesomeWhiteboardSemibold
+      fonts:
+        - asset: lib/fonts/Font-Awesome-7-Whiteboard-Semibold-600.otf
+          weight: 600

--- a/util/lib/main.dart
+++ b/util/lib/main.dart
@@ -630,6 +630,90 @@ bool readAndPickMetadata(
           ),
         ); //"sharp thin ..."
       }
+      if (icon['svgs']?['chisel'] != null) {
+        iconStyles.addAll(
+          (icon['svgs']['chisel'] as Map<String, dynamic>).keys.map(
+            (key) => 'chisel $key',
+          ),
+        ); //"chisel thin ..."
+      }
+      if (icon['svgs']?['etch'] != null) {
+        iconStyles.addAll(
+          (icon['svgs']['etch'] as Map<String, dynamic>).keys.map(
+            (key) => 'etch $key',
+          ),
+        ); //"etch thin ..."
+      }
+      if (icon['svgs']?['graphite'] != null) {
+        iconStyles.addAll(
+          (icon['svgs']['graphite'] as Map<String, dynamic>).keys.map(
+            (key) => 'graphite $key',
+          ),
+        ); //"graphite thin ..."
+      }
+      if (icon['svgs']?['jelly'] != null) {
+        iconStyles.addAll(
+          (icon['svgs']['jelly'] as Map<String, dynamic>).keys.map(
+            (key) => 'jelly $key',
+          ),
+        ); //"jelly thin ..."
+      }
+      if (icon['svgs']?['jelly-fill'] != null) {
+        iconStyles.addAll(
+          (icon['svgs']['jelly-fill'] as Map<String, dynamic>).keys.map(
+            (key) => 'jelly fill $key',
+          ),
+        ); //"jelly fill thin ..."
+      }
+      if (icon['svgs']?['notdog'] != null) {
+        iconStyles.addAll(
+          (icon['svgs']['notdog'] as Map<String, dynamic>).keys.map(
+            (key) => 'notdog $key',
+          ),
+        ); //"notdog thin ..."
+      }
+      if (icon['svgs']?['slab'] != null) {
+        iconStyles.addAll(
+          (icon['svgs']['slab'] as Map<String, dynamic>).keys.map(
+            (key) => 'slab $key',
+          ),
+        ); //"slab thin ..."
+      }
+      if (icon['svgs']?['slab-press'] != null) {
+        iconStyles.addAll(
+          (icon['svgs']['slab-press'] as Map<String, dynamic>).keys.map(
+            (key) => 'slab press $key',
+          ),
+        ); //"slab press thin ..."
+      }
+      if (icon['svgs']?['thumbprint'] != null) {
+        iconStyles.addAll(
+          (icon['svgs']['thumbprint'] as Map<String, dynamic>).keys.map(
+            (key) => 'thumbprint $key',
+          ),
+        ); //"thumbprint thin ..."
+      }
+      if (icon['svgs']?['utility'] != null) {
+        iconStyles.addAll(
+          (icon['svgs']['utility'] as Map<String, dynamic>).keys.map(
+            (key) => 'utility $key',
+          ),
+        ); //"utility thin ..."
+      }
+      if (icon['svgs']?['utility-fill'] != null) {
+        iconStyles.addAll(
+          (icon['svgs']['utility-fill'] as Map<String, dynamic>).keys.map(
+            (key) => 'utility fill $key',
+          ),
+        ); //"utility fill thin ..."
+      }
+      if (icon['svgs']?['whiteboard'] != null) {
+        iconStyles.addAll(
+          (icon['svgs']['whiteboard'] as Map<String, dynamic>).keys.map(
+            (key) => 'whiteboard $key',
+          ),
+        ); //"whiteboard thin ..."
+      }
     }
     //TODO: Remove line once duotone support discontinuation notice is removed
     if (iconStyles.contains('duotone')) hasDuotoneIcons = true;
@@ -638,6 +722,10 @@ bool readAndPickMetadata(
       if (excluded == 'sharp') {
         //Since it's 'sharp thin' then remove any containing sharp
         iconStyles.removeWhere((element) => element.contains('sharp'));
+      } else if (excluded.contains('-')) {
+        iconStyles.removeWhere(
+          (element) => element.contains(excluded.replaceAll('-', ' ')),
+        );
       } else {
         iconStyles.remove(excluded);
       }
@@ -718,6 +806,18 @@ ArgParser setUpArgParser() {
       'light',
       'thin',
       'sharp',
+      'chisel',
+      'etch',
+      'graphite',
+      'jelly',
+      'jelly-fill',
+      'notdog',
+      'slab',
+      'slab-press',
+      'thumbprint',
+      'utility',
+      'utility-fill',
+      'whiteboard',
     ],
     help: 'icon styles which are excluded by the generator',
   );


### PR DESCRIPTION
Hi!

Was using the package and found out I couldn't use all the pro+ icons I had downloaded. I mostly looked at existing code and tried to extend it to support the fonts I had downloaded. If I did it correctly this should be all current fonts excluding any Duo(tone) ones.

I realise the adding of the icon styles may not be the prettiest this way, but it works. Excluding also seems to work fine. I chose for a '-' separating some styles as it felt better for typing in a command line, but I'm open to feedback (also for other stuff).